### PR TITLE
Feat: BaseEntity 추가

### DIFF
--- a/src/main/java/com/patientpal/backend/common/BaseEntity.java
+++ b/src/main/java/com/patientpal/backend/common/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.patientpal.backend.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+}


### PR DESCRIPTION
## ✨ 작업 내용
 - BaseEntity 추가
   - 처음 생성한 사람, 생성 날짜, 수정한 사람, 수정 날짜가 공통적으로 많이 사용될 것 같아서 추상 클래스로 만들었습니다.
   - 이후 필요한 곳에서 상속받아 사용하면 테이블에 위 네 가지 컬럼이 공통으로 자동으로 추가됩니다.

## 💬 리뷰어에게 남길 멘트
 - 일단 네 개 모두 넣었는데 추후 필요 없는 기능은 주석 처리 후 사용해도 될것 같습니다.

## 📚 레퍼런스
- https://eocoding.tistory.com/60
