### PR TITLE
Feat: BaseEntity, BaseTimeEntity 추가

### DIFF
--- a/src/main/java/com/patientpal/backend/common/BaseEntity.java
+++ b/src/main/java/com/patientpal/backend/common/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.patientpal.backend.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+}

--- a/src/main/java/com/patientpal/backend/common/BaseEntity.java
+++ b/src/main/java/com/patientpal/backend/common/BaseEntity.java
@@ -5,28 +5,17 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.*;
 import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @MappedSuperclass
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdDate;
+public abstract class BaseEntity extends BaseTimeEntity {
 
     @CreatedBy
     @Column(updatable = false)
     private String createdBy;
-
-    @LastModifiedDate
-    private LocalDateTime lastModifiedDate;
 
     @LastModifiedBy
     private String lastModifiedBy;

--- a/src/main/java/com/patientpal/backend/common/BaseTimeEntity.java
+++ b/src/main/java/com/patientpal/backend/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.patientpal.backend.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}


### PR DESCRIPTION
## ✨ 작업 내용
- BaseEntity, BaseTimeEntity 추가
  - 처음 생성한 사람, 생성 날짜, 수정한 사람, 수정 날짜가 공통적으로 많이 사용될 것 같아서 추상 클래스로 만들었습니다.
이후 필요한 곳에서 상속받아 사용하면 해당 테이블에 컬럼이 자동으로 추가됩니다.

## 📚 레퍼런스
- https://velog.io/@mooh2jj/JPA-BaseTimeEntity-%EC%84%A4%EC%A0%95