### PR TITLE
Feat: JWT 인증을 통한 일반 로그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
@@ -28,6 +29,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/patientpal/backend/auth/controller/AuthenticationApiV1Controller.java
+++ b/src/main/java/com/patientpal/backend/auth/controller/AuthenticationApiV1Controller.java
@@ -1,0 +1,41 @@
+package com.patientpal.backend.auth.controller;
+
+import com.patientpal.backend.auth.dto.RefreshTokenRequest;
+import com.patientpal.backend.auth.dto.SignInRequest;
+import com.patientpal.backend.auth.dto.SignUpRequest;
+import com.patientpal.backend.auth.dto.TokenResponse;
+import com.patientpal.backend.auth.service.JwtLoginService;
+import com.patientpal.backend.auth.service.JwtTokenService;
+import com.patientpal.backend.member.service.MemberService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthenticationApiV1Controller {
+    private final JwtLoginService loginService;
+    private final JwtTokenService tokenService;
+    private final MemberService memberService;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> authorize(@Valid @RequestBody SignInRequest request) {
+        return ResponseEntity.ok().body(loginService.authenticateUser(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody RefreshTokenRequest request) {
+        return ResponseEntity.ok().body(tokenService.refreshJwtTokens(request));
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> registerMember(@Valid @RequestBody SignUpRequest request) {
+        return ResponseEntity.created(URI.create("/api/v1/members/" + memberService.save(request))).build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/domain/RefreshToken.java
+++ b/src/main/java/com/patientpal/backend/auth/domain/RefreshToken.java
@@ -1,0 +1,38 @@
+package com.patientpal.backend.auth.domain;
+
+import com.patientpal.backend.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String token;
+
+    private Instant expiryDate;
+
+    @Builder
+    public RefreshToken(Member member, String token, Instant expiryDate) {
+        this.member = member;
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/patientpal/backend/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,21 @@
+package com.patientpal.backend.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshTokenRequest {
+    @NotEmpty
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @Builder
+    public RefreshTokenRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/dto/SignInRequest.java
+++ b/src/main/java/com/patientpal/backend/auth/dto/SignInRequest.java
@@ -1,0 +1,28 @@
+package com.patientpal.backend.auth.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignInRequest {
+    @NotEmpty
+    @Length(max = 20)
+    private String username;
+
+    @NotEmpty
+    @Length(min = 8, max = 20)
+    private String password;
+
+    @Builder
+    public SignInRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/dto/SignInRequest.java
+++ b/src/main/java/com/patientpal/backend/auth/dto/SignInRequest.java
@@ -1,6 +1,5 @@
 package com.patientpal.backend.auth.dto;
 
-import jakarta.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,13 +9,11 @@ import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignInRequest {
-    @NotEmpty
     @Length(max = 20)
     private String username;
 
-    @NotEmpty
     @Length(min = 8, max = 20)
     private String password;
 

--- a/src/main/java/com/patientpal/backend/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/patientpal/backend/auth/dto/SignUpRequest.java
@@ -1,0 +1,51 @@
+package com.patientpal.backend.auth.dto;
+
+import com.patientpal.backend.member.domain.Member;
+import com.patientpal.backend.member.domain.Provider;
+import com.patientpal.backend.member.domain.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignUpRequest {
+    @NotBlank
+    @Length(max = 20)
+    private String username;
+
+    @NotBlank
+    @Length(min = 8, max = 20)
+    private String password;
+
+    private String passwordConfirm;
+
+    @NotBlank
+    private String contact;
+
+    @NotNull
+    private Role role;
+
+    @Builder
+    public SignUpRequest(String username, String password, String passwordConfirm, String contact, Role role) {
+        this.username = username;
+        this.password = password;
+        this.passwordConfirm = passwordConfirm;
+        this.contact = contact;
+        this.role = role;
+    }
+
+    public static Member of(SignUpRequest request) {
+        return Member.builder()
+                .username(request.getUsername())
+                .password(request.getPassword())
+                .contact(request.getContact())
+                .provider(Provider.LOCAL)
+                .role(request.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/dto/TokenResponse.java
+++ b/src/main/java/com/patientpal/backend/auth/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.patientpal.backend.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenResponse(@JsonProperty("access_token") String accessToken,
+                            @JsonProperty("refresh_token") String refreshToken) {
+}

--- a/src/main/java/com/patientpal/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/patientpal/backend/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.patientpal.backend.auth.repository;
+
+import com.patientpal.backend.auth.domain.RefreshToken;
+import com.patientpal.backend.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByMemberAndToken(Member member, String token);
+
+    Long deleteByMember(Member member);
+}

--- a/src/main/java/com/patientpal/backend/auth/service/JwtLoginService.java
+++ b/src/main/java/com/patientpal/backend/auth/service/JwtLoginService.java
@@ -1,0 +1,22 @@
+package com.patientpal.backend.auth.service;
+
+import com.patientpal.backend.auth.dto.SignInRequest;
+import com.patientpal.backend.auth.dto.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtLoginService {
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenService tokenService;
+
+    public TokenResponse authenticateUser(SignInRequest request) {
+        var authenticationToken = new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
+        var authentication = authenticationManagerBuilder.getObject()
+                .authenticate(authenticationToken);
+        return tokenService.generateJwtTokens(request.getUsername(), authentication);
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/service/JwtTokenService.java
+++ b/src/main/java/com/patientpal/backend/auth/service/JwtTokenService.java
@@ -1,0 +1,46 @@
+package com.patientpal.backend.auth.service;
+
+import com.patientpal.backend.auth.dto.RefreshTokenRequest;
+import com.patientpal.backend.auth.dto.TokenResponse;
+import com.patientpal.backend.common.exception.AuthenticationException;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+    private final JwtTokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public TokenResponse refreshJwtTokens(RefreshTokenRequest request) {
+        String currentRefreshToken = request.getRefreshToken();
+        validateRefreshToken(currentRefreshToken);
+        var authentication = tokenProvider.getAuthentication(currentRefreshToken);
+        return generateJwtTokens(authentication.getName(), authentication);
+    }
+
+    public TokenResponse generateJwtTokens(String username, Authentication authentication) {
+        String accessToken = tokenProvider.createAccessToken(authentication);
+        String refreshToken = createAndSaveRefreshToken(username, authentication);
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+    private String createAndSaveRefreshToken(String username, Authentication authentication) {
+        String refreshToken = tokenProvider.createRefreshToken(authentication);
+
+        refreshTokenService.deleteTokenByUsername(username);
+        refreshTokenService.save(username, refreshToken);
+
+        return refreshToken;
+    }
+
+    private void validateRefreshToken(String token) {
+        if (!refreshTokenService.validateToken(token)) {
+            throw new AuthenticationException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/com/patientpal/backend/auth/service/LoginService.java
+++ b/src/main/java/com/patientpal/backend/auth/service/LoginService.java
@@ -1,0 +1,29 @@
+package com.patientpal.backend.auth.service;
+
+import com.patientpal.backend.common.exception.EntityNotFoundException;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        var member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST, username));
+        return User.builder()
+                .username(member.getUsername())
+                .password(member.getPassword())
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/patientpal/backend/auth/service/RefreshTokenService.java
@@ -1,0 +1,71 @@
+package com.patientpal.backend.auth.service;
+
+import com.patientpal.backend.auth.domain.RefreshToken;
+import com.patientpal.backend.auth.repository.RefreshTokenRepository;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.common.exception.InvalidValueException;
+import com.patientpal.backend.member.domain.Member;
+import com.patientpal.backend.member.repository.MemberRepository;
+import com.patientpal.backend.security.jwt.JwtTokenProvider;
+import jakarta.transaction.Transactional;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void deleteTokenByUsername(String username) {
+        refreshTokenRepository.deleteByMember(memberRepository.findByUsernameOrThrow(username));
+        refreshTokenRepository.flush();
+    }
+
+    @Transactional
+    public Long save(String username, String token) {
+        var refreshToken = RefreshToken.builder()
+                .member(memberRepository.findByUsernameOrThrow(username))
+                .token(hashToken(token))
+                .expiryDate(Instant.now().plusMillis(tokenProvider.refreshTokenExpirationTime))
+                .build();
+        return refreshTokenRepository.save(refreshToken).getId();
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new InvalidValueException(ErrorCode.TOKEN_HASHING_ERROR);
+        }
+    }
+
+    public boolean validateToken(String token) {
+        if (!tokenProvider.validateToken(token)) {
+            return false;
+        }
+
+        Optional<RefreshToken> storedRefreshToken = getStoredRefreshToken(token);
+        return storedRefreshToken.isPresent() && isTokenNotExpired(storedRefreshToken.get());
+    }
+
+    private Optional<RefreshToken> getStoredRefreshToken(String token) {
+        String username = tokenProvider.getUsernameFromToken(token);
+        Member member = memberRepository.findByUsernameOrThrow(username);
+        return refreshTokenRepository.findByMemberAndToken(member, hashToken(token));
+    }
+
+    public boolean isTokenNotExpired(RefreshToken token) {
+        return !token.getExpiryDate().isBefore(Instant.now());
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/advice/RestApiExceptionHandler.java
+++ b/src/main/java/com/patientpal/backend/common/advice/RestApiExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.patientpal.backend.common.advice;
+
+import com.patientpal.backend.common.exception.BusinessException;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.common.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class RestApiExceptionHandler {
+    @ExceptionHandler(AuthenticationException.class)
+    protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+        var response = ErrorResponse.of(ErrorCode.AUTHENTICATION_FAILED);
+        log.debug("Authentication failed: {}", e.getMessage());
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        var response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+        log.debug("Parameter type is invalid: {}", e.getMessage());
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        var response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+        log.debug("Argument validation has failed: {}", e.getMessage());
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        var response = ErrorResponse.of(e.getErrorCode());
+        log.error("Unexpected error has occurred: {}", e.getDetail());
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        var response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        log.error(e.getMessage(), e);
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/AuthenticationException.java
+++ b/src/main/java/com/patientpal/backend/common/exception/AuthenticationException.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.common.exception;
+
+public class AuthenticationException extends BusinessException {
+    public AuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthenticationException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/AuthorizationException.java
+++ b/src/main/java/com/patientpal/backend/common/exception/AuthorizationException.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.common.exception;
+
+public class AuthorizationException extends BusinessException {
+    public AuthorizationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthorizationException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/BusinessException.java
+++ b/src/main/java/com/patientpal/backend/common/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.patientpal.backend.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String detail;
+
+    public BusinessException(ErrorCode errorCode, String detail) {
+        super(errorCode.getMessage() + (detail == null ? "" : " (" + detail + ")"));
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        this(errorCode, null);
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/EntityNotFoundException.java
+++ b/src/main/java/com/patientpal/backend/common/exception/EntityNotFoundException.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.common.exception;
+
+public class EntityNotFoundException extends BusinessException {
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public EntityNotFoundException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package com.patientpal.backend.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S_001", "서버에 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "S_002", "잘못된 요청 값입니다."),
+    TOKEN_HASHING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S_003", "서버에 오류가 발생했습니다."),
+
+    AUTHORIZATION_FAILED(HttpStatus.FORBIDDEN, "AR_001", "권한이 없습니다."),
+
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AU_001", "이메일 또는 비밀번호가 일치하지 않습니다."),
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "V_001", "유효하지 않은 토큰입니다."),
+
+    MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "M_001", "이미 가입된 계정이 존재합니다."),
+    MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_002", "해당 멤버는 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(final HttpStatus status, final String code, final String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/ErrorResponse.java
+++ b/src/main/java/com/patientpal/backend/common/exception/ErrorResponse.java
@@ -1,0 +1,68 @@
+package com.patientpal.backend.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    private String message;
+    private String code;
+    private List<FieldError> errors;
+
+    @JsonIgnore
+    private HttpStatus status;
+
+    private ErrorResponse(ErrorCode code) {
+        this(code, null);
+    }
+
+    private ErrorResponse(ErrorCode code, List<FieldError> errors) {
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.errors = errors != null ? new ArrayList<>(errors) : Collections.emptyList();
+    }
+
+    public static ErrorResponse of(ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(ErrorCode code, @NonNull BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        @Builder
+        public FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        private static List<FieldError> of(BindingResult bindingResult) {
+            List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> FieldError.builder()
+                            .field(error.getField())
+                            .value(error.getRejectedValue() == null ? "" : error.getRejectedValue().toString())
+                            .reason(error.getDefaultMessage()).build())
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/InvalidValueException.java
+++ b/src/main/java/com/patientpal/backend/common/exception/InvalidValueException.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.common.exception;
+
+public class InvalidValueException extends BusinessException {
+    public InvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidValueException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/patientpal/backend/config/SecurityConfig.java
+++ b/src/main/java/com/patientpal/backend/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.patientpal.backend.config;
+
+import com.patientpal.backend.security.jwt.JwtAccessDeniedHandler;
+import com.patientpal.backend.security.jwt.JwtAuthTokenFilter;
+import com.patientpal.backend.security.jwt.JwtAuthenticationEntryPoint;
+import com.patientpal.backend.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/api/**")
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth
+                            .requestMatchers("/api/v1/auth/**", "/api/v1/docs/**").permitAll()
+                            .anyRequest().authenticated())
+                    .exceptionHandling(handler -> handler
+                            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                            .accessDeniedHandler(jwtAccessDeniedHandler))
+                    .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .addFilterBefore(new JwtAuthTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/member/domain/Member.java
+++ b/src/main/java/com/patientpal/backend/member/domain/Member.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -47,16 +48,13 @@ public class Member {
 
     private LocalDate birthDate;
 
+    @Builder
     public Member(String username, String password, Provider provider, Role role, String contact) {
         this.username = username;
         this.password = password;
         this.provider = provider;
         this.role = role;
         this.contact = contact;
-    }
-
-    public Member(String username, String password, Role role, String contact) {
-        this(username, password, Provider.LOCAL, role, contact);
     }
 
     public void encodePassword(PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/patientpal/backend/member/dto/MemberResponse.java
+++ b/src/main/java/com/patientpal/backend/member/dto/MemberResponse.java
@@ -1,0 +1,24 @@
+package com.patientpal.backend.member.dto;
+
+import com.patientpal.backend.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberResponse {
+    private String username;
+
+    @Builder
+    private MemberResponse(String username) {
+        this.username = username;
+    }
+
+    public static MemberResponse of(final Member member) {
+        return MemberResponse.builder()
+                .username(member.getUsername())
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/patientpal/backend/member/repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package com.patientpal.backend.member.repository;
+
+import com.patientpal.backend.common.exception.EntityNotFoundException;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUsername(String username);
+
+    default Member findByUsernameOrThrow(String username) {
+        return findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST, username));
+    }
+
+    void deleteByUsername(String username);
+}

--- a/src/main/java/com/patientpal/backend/member/service/MemberService.java
+++ b/src/main/java/com/patientpal/backend/member/service/MemberService.java
@@ -1,0 +1,42 @@
+package com.patientpal.backend.member.service;
+
+import com.patientpal.backend.auth.dto.SignUpRequest;
+import com.patientpal.backend.common.exception.AuthenticationException;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.member.domain.Member;
+import com.patientpal.backend.member.dto.MemberResponse;
+import com.patientpal.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public Long save(SignUpRequest request) {
+        try {
+            var member = SignUpRequest.of(request);
+            member.encodePassword(passwordEncoder);
+            return memberRepository.save(member).getId();
+        } catch (DataIntegrityViolationException e) {
+            throw new AuthenticationException(ErrorCode.MEMBER_ALREADY_EXIST, request.getUsername());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResponse findByUsername(String username) {
+        Member foundMember = memberRepository.findByUsernameOrThrow(username);
+        return MemberResponse.of(foundMember);
+    }
+
+    public void deleteByUsername(String username) {
+        memberRepository.deleteByUsername(username);
+    }
+}

--- a/src/main/java/com/patientpal/backend/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/patientpal/backend/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.patientpal.backend.security.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/com/patientpal/backend/security/jwt/JwtAuthTokenFilter.java
+++ b/src/main/java/com/patientpal/backend/security/jwt/JwtAuthTokenFilter.java
@@ -1,0 +1,49 @@
+package com.patientpal.backend.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthTokenFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider tokenProvider;
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String TOKEN_TYPE = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        final String resolvedToken = resolveToken(request);
+
+        if (StringUtils.hasText(resolvedToken) && tokenProvider.validateToken(resolvedToken)) {
+            Authentication authentication = tokenProvider.getAuthentication(resolvedToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("Authenticated user: {}, uri: {}", authentication.getName(), request.getRequestURI());
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (isValidHeader(bearerToken)) {
+            return bearerToken.substring(TOKEN_TYPE.length());
+        }
+        return null;
+    }
+
+    private boolean isValidHeader(String header) {
+        return header != null && header.startsWith(TOKEN_TYPE);
+    }
+}

--- a/src/main/java/com/patientpal/backend/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/patientpal/backend/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.patientpal.backend.security.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
+    }
+}

--- a/src/main/java/com/patientpal/backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/patientpal/backend/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,110 @@
+package com.patientpal.backend.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.sql.Date;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    private static final String AUTHORITIES_KEY = "auth";
+    private Key key;
+
+    private final String base64Secret;
+    public final long refreshTokenExpirationTime;
+    public final long accessTokenExpirationTime;
+
+    public JwtTokenProvider(
+        @Value("${security.jwt.base64-secret}") String base64Secret,
+        @Value("${security.jwt.refresh-expiration-time}") long refreshTokenExpirationTime,
+        @Value("${security.jwt.access-expiration-time}") long accessTokenExpirationTime
+    ) {
+        this.base64Secret = base64Secret;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+        this.accessTokenExpirationTime = accessTokenExpirationTime;
+    }
+
+    public String createToken(Authentication authentication, long expirationTime) {
+        String authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        return createToken(authentication, accessTokenExpirationTime);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return createToken(authentication, refreshTokenExpirationTime);
+    }
+
+    private Jws<Claims> getAllClaimsFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    public String getUsernameFromToken(String token) {
+        return getAllClaimsFromToken(token)
+                .getBody()
+                .getSubject();
+    }
+
+    @PostConstruct
+    public void init() {
+        byte[] secretKeyBytes = Decoders.BASE64.decode(base64Secret);
+        this.key = Keys.hmacShaKeyFor(secretKeyBytes);
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getAllClaimsFromToken(token).getBody();
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(Optional.ofNullable(claims.get(AUTHORITIES_KEY))
+                        .map(Object::toString)
+                        .orElse("")
+                        .split(","))
+                    .map(String::trim)
+                    .filter(auth -> !auth.isEmpty())
+                    .map(SimpleGrantedAuthority::new)
+                    .toList();
+        User principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getAllClaimsFromToken(token);
+            return true;
+        } catch (JwtException ex) {
+            log.trace("Invalid JWT token trace: {}", ex.toString());
+            return false;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,12 @@ jasypt:
     bean: jasyptEncryptorAES
     password: ${JASYPT_ENCRYPTOR_PASSWORD}
 
+security:
+  jwt:
+    base64-secret: ENC(1GNNUxVCM5+Bdl4dwgzuJSkKrKsfQA9+7cTXnd1QCK2oEJKaoF2Z2U/BRqNRDd6C0NLtTpCImGTaXWsFAXNfIpgO4Qg5j1aIKbSxPuCkTfkfgoDGd/kImPKDYGW8XwgbFJsIZsLzFIXbWAC6M0uGTiewFXlel9LX2e3V6Fy9UVU=)
+    access-expiration-time: 86400000
+    refresh-expiration-time: 604800000
+
 ---
 spring:
   config:


### PR DESCRIPTION
## ✨ 작업 내용
- JWT 인증 기능 추가
- 일반 로그인 엔드포인트 추가(/api/v1/login)
- 회원가입 엔드포인트 추가(/api/v1/register)
- REST API 호출 시 발생하는 범용적인 예외 클래스를 정의함

## 💬 리뷰어에게 남길 멘트
- 에러 코드는 제가 임의로 정한 값입니다. 팀원들 간의 상의를 통해 향후에 수정될 수 있습니다.
- 빌더는 부분적이 아니라 코드 일관성을 위해 전체적으로 적용되어야 할 것 같아 `Member` 클래스를 점층적 생성자 패턴에서 빌더 패턴으로 전환했습니다. 검증 로직을 고려하면 피곤해질 것 같아 이대로 제외하고 추후 팀원들과 상의 후 더 좋은 방법을 모색해가겠습니다.

## 🔗 관련 이슈
- #13 