### PR TITLE
Feat: Swagger 관련 세팅 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/patientpal/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/patientpal/backend/config/SwaggerConfig.java
@@ -1,0 +1,58 @@
+package com.patientpal.backend.config;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    private final String devUrl;
+    private final String prodUrl;
+
+    public SwaggerConfig(
+            @Value("${patientpal.openapi.dev-url}") final String devUrl,
+            @Value("${patientpal.openapi.prod-url}") final String prodUrl
+    ) {
+        this.devUrl = devUrl;
+        this.prodUrl = prodUrl;
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        final Server devServer = new Server();
+        devServer.setUrl(devUrl);
+        devServer.description("개발 환경 서버 URL");
+
+//        final Server prodServer = new Server();
+//        prodServer.setUrl(prodUrl);
+//        devServer.description("운영 환경 서버 URL");
+
+        final Info info = new Info()
+                .title("Patientpal API")
+                .version("v1.0.0")
+                .description("Patientpal 팀 Swagger 입니다.");
+
+        // JWT Security Scheme 추가
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name("Authorization")
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("Authorization");
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(devServer/*, prodServer*/))
+                .addSecurityItem(securityRequirement)
+                .components(new io.swagger.v3.oas.models.Components().addSecuritySchemes("Authorization", securityScheme));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,17 @@ jasypt:
     bean: jasyptEncryptorAES
     password: ${JASYPT_ENCRYPTOR_PASSWORD}
 
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /api-docs
+
+patientpal:
+  openapi:
+    dev-url: http://localhost:8080
+    prod-url: https://prod-api.patientpal.com
+
 ---
 spring:
   config:


### PR DESCRIPTION
## ✨ 작업 내용
- build.gradle에 swagger 의존성 추가
   - 스웨거를 지원하는 라이브러리는 springfox와 springdoc 가 있는데, fox는 오래된 라이브러리이고, 20년 7월 이후 업데이트가 멈추었습니다. doc은 업데이트가 꾸준히 진행중이고, 스프링 3.x 이후 버전도 지원하기에 doc을 선택하였습니다.
   
- SwaggerConfig 파일을 통해 설정을 추가하였습니다.
  - 개발환경서버와 운영환경서버를 나누어 등록하였습니다. 
  - 운영환경서버는 서버 배포 후 운영 과정에서 진행하기 위해 주석 처리 후 개발환경서버만 등록하였습니다.
  - JWT 관련 설정을 추가하여, swagger 안에서 token값을 넣어 등록하면, request헤더에 토큰값을 일일이 넣지 않아도 자동으로 포함되도록 진행할 수 있도록 설정하였습니다. (밑 사진 참조)
  
- application.yml에 swagger관련 설정을 추가하였습니다.
  -  [lo](http://localhost:8080/swagger-ui.html) 로 접근 가능합니다.
  - api docs를 보기 위한 url은 [lo](http://localhost:8080/api-docs) 입니다.
![image](https://github.com/goaheadgogo/backend/assets/128116509/31a1f802-c1f5-4d67-9e1c-597dd972057a)
![image](https://github.com/goaheadgogo/backend/assets/128116509/e0168c32-59a8-4e24-b07a-68cb04349735)


## 💬 리뷰어에게 남길 멘트
- 보안상 문제가 있는지 확인해주세요
- 제대로 동작하는지 확인해주세요
- 추후 security와 통합시 swagger 관련한 url을 허용하는 작업이 필요합니다.

## 📚 레퍼런스
- https://woo-chang.tistory.com/80
- https://wonsjung.tistory.com/584