### PR TITLE
Feat: 두 필드가 서로 일치하는지 검증하는 @FieldMatch을 추가함

### DIFF
--- a/src/main/java/com/patientpal/backend/common/validation/FieldMatchValidator.java
+++ b/src/main/java/com/patientpal/backend/common/validation/FieldMatchValidator.java
@@ -1,0 +1,34 @@
+package com.patientpal.backend.common.validation;
+
+import com.patientpal.backend.common.validation.constraints.FieldMatch;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyAccessorFactory;
+
+public class FieldMatchValidator implements ConstraintValidator<FieldMatch, Object> {
+    private String firstFieldName;
+    private String secondFieldName;
+
+    @Override
+    public void initialize(FieldMatch constraintAnnotation) {
+        this.firstFieldName = constraintAnnotation.first();
+        this.secondFieldName = constraintAnnotation.second();
+    }
+
+    @Override
+    public boolean isValid(Object o, ConstraintValidatorContext constraintValidatorContext) {
+        final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(o);
+
+        try {
+            final Object firstValue = wrapper.getPropertyValue(firstFieldName);
+            final Object secondValue = wrapper.getPropertyValue(secondFieldName);
+
+            return Objects.equals(firstValue, secondValue);
+        } catch (BeansException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/validation/constraints/FieldMatch.java
+++ b/src/main/java/com/patientpal/backend/common/validation/constraints/FieldMatch.java
@@ -1,0 +1,39 @@
+package com.patientpal.backend.common.validation.constraints;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+
+import com.patientpal.backend.common.validation.FieldMatchValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = FieldMatchValidator.class)
+public @interface FieldMatch {
+    String message() default "{com.patientpal.backend.common.validation.constraints.FieldMatch.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<?>[] payload() default {};
+
+    /**
+     * @return 매치되어야 하는 첫 번째 필드 이름
+     */
+    String first();
+
+    /**
+     * @return 매치되어야 하는 두 번째 필드 이름
+     */
+    String second();
+
+    @Target({TYPE, ANNOTATION_TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface List {
+        FieldMatch[] value();
+    }
+}

--- a/src/test/java/com/patientpal/backend/common/validation/FieldMatchValidatorTest.java
+++ b/src/test/java/com/patientpal/backend/common/validation/FieldMatchValidatorTest.java
@@ -1,0 +1,54 @@
+package com.patientpal.backend.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.patientpal.backend.auth.dto.SignUpRequest;
+import com.patientpal.backend.common.validation.constraints.FieldMatch;
+import com.patientpal.backend.fixtures.member.SignUpRequestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("@FieldMatch 유효성 검사")
+class FieldMatchValidatorTest {
+    private FieldMatchValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new FieldMatchValidator();
+
+        FieldMatch annotation = mock(FieldMatch.class);
+        when(annotation.first()).thenReturn("password");
+        when(annotation.second()).thenReturn("passwordConfirm");
+
+        validator.initialize(annotation);
+    }
+
+    @Test
+    @DisplayName("서로 일치하면 유효성 검사가 성공한다.")
+    void success() {
+        // given
+        SignUpRequest request = SignUpRequestFixture.createValidSignUpRequest();
+
+        // when
+        boolean result = validator.isValid(request, null);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("서로 일치하지 않으면 유효성 검사가 실패한다.")
+    void fail() {
+        // given
+        SignUpRequest request = SignUpRequestFixture.createSignUpRequestWithMismatchedPasswords();
+
+        // when
+        boolean result = validator.isValid(request, null);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/patientpal/backend/fixtures/member/SignUpRequestFixture.java
+++ b/src/test/java/com/patientpal/backend/fixtures/member/SignUpRequestFixture.java
@@ -1,0 +1,26 @@
+package com.patientpal.backend.fixtures.member;
+
+import com.patientpal.backend.auth.dto.SignUpRequest;
+import com.patientpal.backend.member.domain.Role;
+
+public class SignUpRequestFixture {
+    public static SignUpRequest createValidSignUpRequest() {
+        return SignUpRequest.builder()
+                .username("validUser")
+                .password("validPassword123")
+                .passwordConfirm("validPassword123")
+                .contact("validContact@example.com")
+                .role(Role.USER)
+                .build();
+    }
+
+    public static SignUpRequest createSignUpRequestWithMismatchedPasswords() {
+        return SignUpRequest.builder()
+                .username("validUser")
+                .password("validPassword123")
+                .passwordConfirm("differentPassword")
+                .contact("validContact@example.com")
+                .role(Role.USER)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 두 필드가 서로 일치하는지 검증하는 `@FieldMatch` 애노테이션을 추가했습니다.

## 💬 리뷰어에게 남길 멘트
- 아마도 회원가입 요청 시 비밀번호와 비밀번호 확인이 서로 일치하는지 확인할 수 있을 것 같습니다.

## 🔗 관련 이슈
- close #32 