### PR TITLE
Feat: 스네이크 케이스로 작성된 테스트 클래스명이나 메서드명을 통해 `@DisplayName`을 자동으로 달게함

### DIFF
--- a/src/test/java/com/patientpal/backend/test/annotation/AutoKoreanDisplayName.java
+++ b/src/test/java/com/patientpal/backend/test/annotation/AutoKoreanDisplayName.java
@@ -1,0 +1,14 @@
+package com.patientpal.backend.test.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public @interface AutoKoreanDisplayName {
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 스네이크 케이스로 작성된 테스트 클래스명이나 메서드명을 통해 `@DisplayName`을 자동으로 달게함

## 💬 리뷰어에게 남길 멘트
- 리플렉션을 이용해야 하나 싶었는데 이미 JUnit에 만들어진 애노테이션이 있어서 그냥 이름 단축만 한 것 같습니다 😄

```java
@AutoKoreanDisplayName
@SuppressWarnings("NonAsciiCharacters")
class CaregiverControllerV1Test extends CommonControllerSliceTest {

    @Autowired
    CaregiverService caregiverService;

    @Nested
    class 간병인_프로필_생성 {

        @Test
        @WithCustomMockUserCaregiver
        void 간병인_프로필을_성공적으로_생성한다() throws Exception {
                ...
        }
        ...
}
```

## 🔗 관련 이슈
- close #68 