### PR TITLE
Feat: AWS S3, presigned url을 이용한 이미지 등록 기능, 테스트 구현함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
+++ b/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
@@ -7,7 +7,7 @@ import com.patientpal.backend.caregiver.dto.request.CaregiverProfileCreateReques
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileUpdateRequest;
 import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
 import com.patientpal.backend.caregiver.service.CaregiverService;
-import com.patientpal.backend.image.dto.ImageNameDTO;
+import com.patientpal.backend.image.dto.ImageNameDto;
 import com.patientpal.backend.image.service.PresignedUrlService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,9 +34,9 @@ public class CaregiverControllerV1 {
     }
 
     @PostMapping("/presigned")
-    public String createPresigned(@RequestBody ImageNameDTO imageNameDTO) {
-        path ="profiles";
-        String imageName = imageNameDTO.getImageName();
+    public String createPresigned(@RequestBody ImageNameDto imageNameDto) {
+        path = "profiles";
+        String imageName = imageNameDto.getImageName();
         return presignedUrlService.getPresignedUrl(path, imageName);
     }
 

--- a/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
+++ b/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
@@ -9,6 +9,11 @@ import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
 import com.patientpal.backend.caregiver.service.CaregiverService;
 import com.patientpal.backend.image.dto.ImageNameDto;
 import com.patientpal.backend.image.service.PresignedUrlService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +21,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "간병인", description = "간병인 프로필 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/caregiver")
@@ -25,14 +31,19 @@ public class CaregiverControllerV1 {
     private final PresignedUrlService presignedUrlService;
     private String path;
 
+    @Operation(summary = "간병인 프로필 생성", description = "간병인 프로필을 새로 생성합니다. 선택적으로 이미지를 업로드할 수 있습니다.")
+    @ApiResponse(responseCode = "201", description = "간병인 프로필 생성 성공", content = @Content(schema = @Schema(implementation = CaregiverProfileResponse.class)))
     @PostMapping
-    public ResponseEntity<CaregiverProfileResponse> createCaregiverProfile(@AuthenticationPrincipal User currentMember,
-                                                     @RequestBody @Valid CaregiverProfileCreateRequest CaregiverProfileCreateRequest) {
+    public ResponseEntity<CaregiverProfileResponse> createCaregiverProfile(
+            @AuthenticationPrincipal User currentMember,
+            @RequestBody @Valid CaregiverProfileCreateRequest caregiverProfileCreateRequest) {
         String profileImageUrl = presignedUrlService.findByName(path);
-        CaregiverProfileResponse caregiverProfileResponse = caregiverService.saveCaregiverProfile(currentMember.getUsername(), CaregiverProfileCreateRequest, profileImageUrl);
+        CaregiverProfileResponse caregiverProfileResponse = caregiverService.saveCaregiverProfile(currentMember.getUsername(), caregiverProfileCreateRequest, profileImageUrl);
         return ResponseEntity.status(CREATED).body(caregiverProfileResponse);
     }
 
+    @Operation(summary = "AWS S3에 저장될 전체 URL 경로 생성", description = "이미지 업로드를 위한 URL을 생성합니다. 생성된 URL로 파일 첨부 후 PUTMAPPING 진행 시 이미지가 저장됩니다.")
+    @ApiResponse(responseCode = "200", description = "생성 성공")
     @PostMapping("/presigned")
     public String createPresigned(@RequestBody ImageNameDto imageNameDto) {
         path = "profiles";
@@ -40,39 +51,57 @@ public class CaregiverControllerV1 {
         return presignedUrlService.getPresignedUrl(path, imageName);
     }
 
+    @Operation(summary = "간병인 프로필 조회", description = "현재 로그인된 사용자의 간병인 프로필을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "간병인 프로필 조회 성공", content = @Content(schema = @Schema(implementation = CaregiverProfileResponse.class)))
     @GetMapping
-    public ResponseEntity<CaregiverProfileResponse> getCaregiverProfile(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<CaregiverProfileResponse> getCaregiverProfile(
+            @AuthenticationPrincipal User currentMember) {
         return ResponseEntity.status(OK).body(caregiverService.getProfile(currentMember.getUsername()));
     }
 
+    @Operation(summary = "간병인 프로필 수정", description = "간병인 프로필 정보를 수정합니다.")
+    @ApiResponse(responseCode = "204", description = "간병인 프로필 수정 성공")
     @PatchMapping
-    public ResponseEntity<Void> updateCaregiverProfile(@AuthenticationPrincipal User currentMember,
-                                                       @RequestBody @Valid CaregiverProfileUpdateRequest caregiverProfileUpdateRequest) {
+    public ResponseEntity<Void> updateCaregiverProfile(
+            @AuthenticationPrincipal User currentMember,
+            @RequestBody @Valid CaregiverProfileUpdateRequest caregiverProfileUpdateRequest) {
         String profileImageUrl = presignedUrlService.findByName(path);
         caregiverService.updateCaregiverProfile(currentMember.getUsername(), caregiverProfileUpdateRequest, profileImageUrl);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "간병인 프로필 삭제", description = "간병인 프로필을 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "간병인 프로필 삭제 성공")
     @DeleteMapping
-    public ResponseEntity<Void> deleteCaregiverProfile(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> deleteCaregiverProfile(
+            @AuthenticationPrincipal User currentMember) {
         caregiverService.deleteCaregiverProfile(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "간병인 프로필 이미지 삭제", description = "간병인 프로필에서 이미지를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "간병인 프로필 이미지 삭제 성공")
     @DeleteMapping("/image")
-    public ResponseEntity<Void> deleteCaregiverProfileImage(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> deleteCaregiverProfileImage(
+            @AuthenticationPrincipal User currentMember) {
         caregiverService.deleteCaregiverProfileImage(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "간병인 프로필 매칭 리스트에 등록", description = "간병인 프로필을 매칭 리스트에 등록합니다.")
+    @ApiResponse(responseCode = "204", description = "간병인 프로필 매칭 리스트 등록 성공")
     @PostMapping("register/toMatchList")
-    public ResponseEntity<Void> registerCaregiverProfileToMatchList(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> registerCaregiverProfileToMatchList(
+            @AuthenticationPrincipal User currentMember) {
         caregiverService.registerCaregiverProfileToMatchList(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "간병인 프로필 매칭 리스트에서 제거", description = "간병인 프로필을 매칭 리스트에서 제거합니다.")
+    @ApiResponse(responseCode = "204", description = "간병인 프로필 매칭 리스트 제거 성공")
     @PostMapping("unregister/toMatchList")
-    public ResponseEntity<Void> unregisterCaregiverProfileToMatchList(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> unregisterCaregiverProfileToMatchList(
+            @AuthenticationPrincipal User currentMember) {
         caregiverService.unregisterCaregiverProfileToMatchList(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/patientpal/backend/caregiver/domain/Caregiver.java
+++ b/src/main/java/com/patientpal/backend/caregiver/domain/Caregiver.java
@@ -69,9 +69,12 @@ public class Caregiver extends BaseTimeEntity {
     @Setter
     private Boolean isInMatchList;
 
+    @Lob
+    private String profileImageUrl;
+
     @Builder
     public Caregiver(Member member, String name, String residentRegistrationNumber, String phoneNumber, Address address,
-                     float rating, int experienceYears, String specialization, String caregiverSignificant, Boolean isInMatchList) {
+                     float rating, int experienceYears, String specialization, String caregiverSignificant, Boolean isInMatchList, String profileImageUrl) {
         this.member = member;
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
@@ -82,13 +85,19 @@ public class Caregiver extends BaseTimeEntity {
         this.specialization = specialization;
         this.caregiverSignificant = caregiverSignificant;
         this.isInMatchList = isInMatchList;
+        this.profileImageUrl = profileImageUrl;
     }
 
-    public void updateDetailProfile(final Address address, final float rate, final int experienceYears, final String specialization, final String caregiverSignificant) {
+    public void updateDetailProfile(final Address address, final float rate, final int experienceYears, final String specialization, final String caregiverSignificant, final String profileImageUrl) {
         this.address = address;
         this.rating = rate;
         this.experienceYears = experienceYears;
         this.specialization = specialization;
         this.caregiverSignificant = caregiverSignificant;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void deleteProfileImage() {
+        this.profileImageUrl = null;
     }
 }

--- a/src/main/java/com/patientpal/backend/caregiver/dto/request/CaregiverProfileCreateRequest.java
+++ b/src/main/java/com/patientpal/backend/caregiver/dto/request/CaregiverProfileCreateRequest.java
@@ -48,7 +48,7 @@ public class CaregiverProfileCreateRequest {
         this.caregiverSignificant = caregiverSignificant;
     }
 
-    public Caregiver toEntity(Member member) {
+    public Caregiver toEntity(Member member, String profileImageUrl) {
         return Caregiver.builder()
                 .name(this.name)
                 .residentRegistrationNumber(this.residentRegistrationNumber)
@@ -60,6 +60,7 @@ public class CaregiverProfileCreateRequest {
                 .specialization(this.specialization)
                 .caregiverSignificant(this.caregiverSignificant)
                 .isInMatchList(false)
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/patientpal/backend/caregiver/service/CaregiverService.java
+++ b/src/main/java/com/patientpal/backend/caregiver/service/CaregiverService.java
@@ -30,12 +30,12 @@ public class CaregiverService {
     private final MatchRepository matchRepository;
 
     @Transactional
-    public CaregiverProfileResponse saveCaregiverProfile(String username, CaregiverProfileCreateRequest caregiverProfileCreateRequest) {
+    public CaregiverProfileResponse saveCaregiverProfile(String username, CaregiverProfileCreateRequest caregiverProfileCreateRequest, String profileImageUrl) {
         Member currentMember = getMember(username);
         // TODO 본인 인증 진행, 중복 가입이면 throw
         validateAuthorization(currentMember);
         validateDuplicateCaregiver(currentMember);
-        Caregiver savedCaregiver = caregiverRepository.save(caregiverProfileCreateRequest.toEntity(currentMember));
+        Caregiver savedCaregiver = caregiverRepository.save(caregiverProfileCreateRequest.toEntity(currentMember, profileImageUrl));
         log.info("프로필 등록 성공: ID={}, NAME={}", savedCaregiver.getId(), savedCaregiver.getName());
         return CaregiverProfileResponse.of(savedCaregiver);
     }
@@ -59,14 +59,15 @@ public class CaregiverService {
     }
 
     @Transactional
-    public void updateCaregiverProfile(String username, CaregiverProfileUpdateRequest caregiverProfileUpdateRequest) {
+    public void updateCaregiverProfile(String username, CaregiverProfileUpdateRequest caregiverProfileUpdateRequest, String profileImageUrl) {
         Member currentMember = getMember(username);
         getCaregiver(currentMember).updateDetailProfile(
                 caregiverProfileUpdateRequest.getAddress(),
                 caregiverProfileUpdateRequest.getRating(),
                 caregiverProfileUpdateRequest.getExperienceYears(),
                 caregiverProfileUpdateRequest.getSpecialization(),
-                caregiverProfileUpdateRequest.getCaregiverSignificant()
+                caregiverProfileUpdateRequest.getCaregiverSignificant(),
+                profileImageUrl
         );
     }
 
@@ -107,5 +108,12 @@ public class CaregiverService {
 
     private Caregiver getCaregiver(Member currentMember) {
         return caregiverRepository.findByMember(currentMember).orElseThrow(() -> new EntityNotFoundException(ErrorCode.CAREGIVER_NOT_EXIST));
+    }
+
+    @Transactional
+    public void deleteCaregiverProfileImage(String username) {
+        Member member = getMember(username);
+        Caregiver caregiver = getCaregiver(member);
+        caregiver.deleteProfileImage();
     }
 }

--- a/src/main/java/com/patientpal/backend/config/S3Config.java
+++ b/src/main/java/com/patientpal/backend/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.patientpal.backend.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    @Primary
+    public BasicAWSCredentials awsCredentialsProvider() {
+        return new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/image/dto/ImageNameDTO.java
+++ b/src/main/java/com/patientpal/backend/image/dto/ImageNameDTO.java
@@ -1,0 +1,14 @@
+package com.patientpal.backend.image.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class ImageNameDTO {
+    private final String imageName;
+
+    public ImageNameDTO(String imageName) {
+        this.imageName = imageName;
+    }
+}

--- a/src/main/java/com/patientpal/backend/image/dto/ImageNameDto.java
+++ b/src/main/java/com/patientpal/backend/image/dto/ImageNameDto.java
@@ -5,10 +5,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(force = true)
-public class ImageNameDTO {
+public class ImageNameDto {
     private final String imageName;
 
-    public ImageNameDTO(String imageName) {
+    public ImageNameDto(String imageName) {
         this.imageName = imageName;
     }
 }

--- a/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
+++ b/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
@@ -42,9 +42,8 @@ public class PresignedUrlService {
         return url.toString();
     }
 
-    private String onlyOneFileName(String filename){
-        return UUID.randomUUID().toString()+filename;
-
+    private String onlyOneFileName(String filename) {
+        return UUID.randomUUID().toString() + filename;
     }
 
     private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {
@@ -71,6 +70,6 @@ public class PresignedUrlService {
 
     public String findByName(String path) {
         log.info("Generating signed URL for file name = {}", useOnlyOneFileName);
-        return "https://"+bucket+".s3."+location+".amazonaws.com/"+path+"/"+useOnlyOneFileName;
+        return "https://" + bucket + ".s3." + location + ".amazonaws.com/" + path + "/" + useOnlyOneFileName;
     }
 }

--- a/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
+++ b/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
@@ -1,0 +1,76 @@
+package com.patientpal.backend.image.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PresignedUrlService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.region.static}")
+    private String location;
+
+    private String useOnlyOneFileName;
+
+    public String getPresignedUrl(String prefix, String fileName) {
+        String onlyOneFileName = onlyOneFileName(fileName);
+
+        useOnlyOneFileName = onlyOneFileName;
+
+        if (!prefix.isEmpty()) {
+            onlyOneFileName = prefix + "/" + onlyOneFileName;
+        }
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, onlyOneFileName);
+        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return url.toString();
+    }
+
+    private String onlyOneFileName(String filename){
+        return UUID.randomUUID().toString()+filename;
+
+    }
+
+    private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(getPresignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL,
+                CannedAccessControlList.PublicRead.toString()
+        );
+
+        return generatePresignedUrlRequest;
+    }
+
+    private Date getPresignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 2;
+        expiration.setTime(expTimeMillis);
+
+        return expiration;
+    }
+
+    public String findByName(String path) {
+        log.info("Generating signed URL for file name = {}", useOnlyOneFileName);
+        return "https://"+bucket+".s3."+location+".amazonaws.com/"+path+"/"+useOnlyOneFileName;
+    }
+}

--- a/src/main/java/com/patientpal/backend/patient/controller/PatientControllerV1.java
+++ b/src/main/java/com/patientpal/backend/patient/controller/PatientControllerV1.java
@@ -9,19 +9,19 @@ import com.patientpal.backend.patient.dto.request.PatientProfileCreateRequest;
 import com.patientpal.backend.patient.dto.request.PatientProfileUpdateRequest;
 import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
 import com.patientpal.backend.patient.service.PatientService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "환자", description = "환자 프로필 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/patient")
@@ -31,14 +31,19 @@ public class PatientControllerV1 {
     private final PresignedUrlService presignedUrlService;
     private String path;
 
+    @Operation(summary = "환자 프로필 생성", description = "환자 프로필을 새로 생성합니다. 선택적으로 이미지를 업로드할 수 있습니다.")
+    @ApiResponse(responseCode = "201", description = "환자 프로필 생성 성공", content = @Content(schema = @Schema(implementation = PatientProfileResponse.class)))
     @PostMapping
-    public ResponseEntity<PatientProfileResponse> createPatientProfile(@AuthenticationPrincipal User currentMember,
-                                                     @RequestBody @Valid PatientProfileCreateRequest patientProfileCreateRequest) {
+    public ResponseEntity<PatientProfileResponse> createPatientProfile(
+            @AuthenticationPrincipal User currentMember,
+            @RequestBody @Valid PatientProfileCreateRequest patientProfileCreateRequest) {
         String profileImageUrl = presignedUrlService.findByName(path);
         PatientProfileResponse patientProfileResponse = patientService.savePatientProfile(currentMember.getUsername(), patientProfileCreateRequest, profileImageUrl);
         return ResponseEntity.status(CREATED).body(patientProfileResponse);
     }
 
+    @Operation(summary = "AWS S3에 저장될 전체 URL 경로 생성", description = "이미지 업로드를 위한 URL을 생성합니다. 생성된 URL로 파일 첨부 후 PUTMAPPING 진행 시 이미지가 저장됩니다.")
+    @ApiResponse(responseCode = "200", description = "생성 성공")
     @PostMapping("/presigned")
     public String createPresigned(@RequestBody ImageNameDto imageNameDto) {
         path = "profiles";
@@ -46,39 +51,57 @@ public class PatientControllerV1 {
         return presignedUrlService.getPresignedUrl(path, imageName);
     }
 
+    @Operation(summary = "환자 프로필 조회", description = "현재 로그인된 사용자의 환자 프로필을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "환자 프로필 조회 성공", content = @Content(schema = @Schema(implementation = PatientProfileResponse.class)))
     @GetMapping
-    public ResponseEntity<PatientProfileResponse> getPatientProfile(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<PatientProfileResponse> getPatientProfile(
+            @AuthenticationPrincipal User currentMember) {
         return ResponseEntity.status(OK).body(patientService.getProfile(currentMember.getUsername()));
     }
 
+    @Operation(summary = "환자 프로필 수정", description = "환자 프로필 정보를 수정합니다.")
+    @ApiResponse(responseCode = "204", description = "환자 프로필 수정 성공")
     @PatchMapping
-    public ResponseEntity<Void> updatePatientProfile(@AuthenticationPrincipal User currentMember,
-                                                     @RequestBody @Valid PatientProfileUpdateRequest patientProfileUpdateRequest) {
+    public ResponseEntity<Void> updatePatientProfile(
+            @AuthenticationPrincipal User currentMember,
+            @RequestBody @Valid PatientProfileUpdateRequest patientProfileUpdateRequest) {
         String profileImageUrl = presignedUrlService.findByName(path);
         patientService.updatePatientProfile(currentMember.getUsername(), patientProfileUpdateRequest, profileImageUrl);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "환자 프로필 삭제", description = "환자 프로필을 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "환자 프로필 삭제 성공")
     @DeleteMapping
-    public ResponseEntity<Void> deletePatientProfile(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> deletePatientProfile(
+            @AuthenticationPrincipal User currentMember) {
         patientService.deletePatientProfile(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "환자 프로필 이미지 삭제", description = "환자 프로필에서 이미지를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "환자 프로필 이미지 삭제 성공")
     @DeleteMapping("/image")
-    public ResponseEntity<Void> deletePatientProfileImage(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> deletePatientProfileImage(
+            @AuthenticationPrincipal User currentMember) {
         patientService.deletePatientProfileImage(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "환자 프로필 매칭 리스트에 등록", description = "환자 프로필을 매칭 리스트에 등록합니다.")
+    @ApiResponse(responseCode = "204", description = "환자 프로필 매칭 리스트 등록 성공")
     @PostMapping("register/toMatchList")
-    public ResponseEntity<Void> registerPatientProfileToMatchList(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> registerPatientProfileToMatchList(
+            @AuthenticationPrincipal User currentMember) {
         patientService.registerPatientProfileToMatchList(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "환자 프로필 매칭 리스트에서 제거", description = "환자 프로필을 매칭 리스트에서 제거합니다.")
+    @ApiResponse(responseCode = "204", description = "환자 프로필 매칭 리스트 제거 성공")
     @PostMapping("unregister/toMatchList")
-    public ResponseEntity<Void> unregisterPatientProfileToMatchList(@AuthenticationPrincipal User currentMember) {
+    public ResponseEntity<Void> unregisterPatientProfileToMatchList(
+            @AuthenticationPrincipal User currentMember) {
         patientService.unregisterPatientProfileToMatchList(currentMember.getUsername());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/patientpal/backend/patient/controller/PatientControllerV1.java
+++ b/src/main/java/com/patientpal/backend/patient/controller/PatientControllerV1.java
@@ -3,7 +3,7 @@ package com.patientpal.backend.patient.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-import com.patientpal.backend.image.dto.ImageNameDTO;
+import com.patientpal.backend.image.dto.ImageNameDto;
 import com.patientpal.backend.image.service.PresignedUrlService;
 import com.patientpal.backend.patient.dto.request.PatientProfileCreateRequest;
 import com.patientpal.backend.patient.dto.request.PatientProfileUpdateRequest;
@@ -40,9 +40,9 @@ public class PatientControllerV1 {
     }
 
     @PostMapping("/presigned")
-    public String createPresigned(@RequestBody ImageNameDTO imageNameDTO) {
-        path ="profiles";
-        String imageName = imageNameDTO.getImageName();
+    public String createPresigned(@RequestBody ImageNameDto imageNameDto) {
+        path = "profiles";
+        String imageName = imageNameDto.getImageName();
         return presignedUrlService.getPresignedUrl(path, imageName);
     }
 

--- a/src/main/java/com/patientpal/backend/patient/domain/Patient.java
+++ b/src/main/java/com/patientpal/backend/patient/domain/Patient.java
@@ -70,9 +70,12 @@ public class Patient extends BaseTimeEntity {
     @Setter
     private Boolean isInMatchList;
 
+    @Lob
+    private String profileImageUrl;
+
     @Builder
     public Patient(Member member, String name, String residentRegistrationNumber, String phoneNumber, Address address,
-                   String nokName, String nokContact, String patientSignificant, String careRequirements, Boolean isInMatchList) {
+                   String nokName, String nokContact, String patientSignificant, String careRequirements, Boolean isInMatchList, String profileImageUrl) {
         this.member = member;
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
@@ -83,13 +86,19 @@ public class Patient extends BaseTimeEntity {
         this.patientSignificant = patientSignificant;
         this.careRequirements = careRequirements;
         this.isInMatchList = isInMatchList;
+        this.profileImageUrl = profileImageUrl;
     }
 
-    public void updateDetailProfile(final Address address, final String nokName, final String nokContact, final String patientSignificant, final String careRequirements) {
+    public void updateDetailProfile(final Address address, final String nokName, final String nokContact, final String patientSignificant, final String careRequirements, final String profileImageUrl) {
         this.address = address;
         this.nokName = nokName;
         this.nokContact = nokContact;
         this.patientSignificant = patientSignificant;
         this.careRequirements = careRequirements;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void deleteProfileImage() {
+        this.profileImageUrl = null;
     }
 }

--- a/src/main/java/com/patientpal/backend/patient/dto/request/PatientProfileCreateRequest.java
+++ b/src/main/java/com/patientpal/backend/patient/dto/request/PatientProfileCreateRequest.java
@@ -47,7 +47,7 @@ public class PatientProfileCreateRequest {
         this.careRequirements = careRequirements;
     }
 
-    public Patient toEntity(Member member) {
+    public Patient toEntity(Member member, String profileImageUrl) {
         return Patient.builder()
                 .name(this.name)
                 .residentRegistrationNumber(this.residentRegistrationNumber)
@@ -59,6 +59,7 @@ public class PatientProfileCreateRequest {
                 .patientSignificant(this.patientSignificant)
                 .careRequirements(this.careRequirements)
                 .isInMatchList(false)
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileResponse.java
+++ b/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileResponse.java
@@ -31,8 +31,11 @@ public class PatientProfileResponse {
 
     private Boolean isInMatchList;
 
+    private String image;
+
     @Builder
-    public PatientProfileResponse(Long memberId, String name, String residentRegistrationNumber, String phoneNumber, Address address, String nokName, String nokContact, String patientSignificant, String careRequirements, Boolean isInMatchList) {
+    public PatientProfileResponse(Long memberId, String name, String residentRegistrationNumber, String phoneNumber, Address address, String nokName, String nokContact,
+                                  String patientSignificant, String careRequirements, Boolean isInMatchList, String image) {
         this.memberId = memberId;
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
@@ -43,6 +46,7 @@ public class PatientProfileResponse {
         this.patientSignificant = patientSignificant;
         this.careRequirements = careRequirements;
         this.isInMatchList = isInMatchList;
+        this.image = image;
     }
 
     public static PatientProfileResponse of(Patient patient) {
@@ -57,6 +61,7 @@ public class PatientProfileResponse {
                 .patientSignificant(patient.getPatientSignificant())
                 .careRequirements(patient.getCareRequirements())
                 .isInMatchList(patient.getIsInMatchList())
+                .image(patient.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,16 @@ patientpal:
     dev-url: http://localhost:8080
     prod-url: http://43.201.129.48:8080
 
+cloud:
+  aws:
+    s3:
+      bucket: ENC(CjiT7j7b7u1wlFVqx0zB2ujnopCuig1+1T3wOX5CIhiFTMFE8WaI27gH//lGbZZP)
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ENC(r04YXWG07hMBoYq5t2XkJi4aj4M70jctIk56GcTh8+Zlmq7DiFrfvFIZ4mBZTXUosLtIvBY6ww35G1dP75xBzQ==)
+      secretKey: ENC(s4Uba61I+DdhipLPJMTjQh+7QbyIU9Si2VsmsMoDqM/IIIcH5ZuKGpbawjuSFH61u24G9CNEbZuSRqq4b45oGcCt8Om4/kgDAn5bq20TPwI=)
+
 ---
 spring:
   config:

--- a/src/test/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1Test.java
+++ b/src/test/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1Test.java
@@ -19,11 +19,11 @@ import com.patientpal.backend.caregiver.dto.request.CaregiverProfileCreateReques
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileUpdateRequest;
 import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
 import com.patientpal.backend.caregiver.service.CaregiverService;
-import com.patientpal.backend.test.annotation.WithCustomMockUserCaregiver;
 import com.patientpal.backend.common.exception.EntityNotFoundException;
 import com.patientpal.backend.common.exception.ErrorCode;
 import com.patientpal.backend.test.CommonControllerSliceTest;
 import com.patientpal.backend.test.annotation.AutoKoreanDisplayName;
+import com.patientpal.backend.test.annotation.WithCustomMockUserCaregiver;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +45,7 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
             // given
             CaregiverProfileCreateRequest request = createCaregiverProfileRequest();
             CaregiverProfileResponse response = createCaregiverProfileResponse();
-            given(caregiverService.saveCaregiverProfile(any(String.class), any(CaregiverProfileCreateRequest.class))).willReturn(response);
+            given(caregiverService.saveCaregiverProfile(any(String.class), any(CaregiverProfileCreateRequest.class), any())).willReturn(response);
 
             // when & then
             mockMvc.perform(post("/api/v1/caregiver")
@@ -115,7 +115,7 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
         void 성공한다() throws Exception {
             // given
             CaregiverProfileUpdateRequest request = updateCaregiverProfileRequest();
-            willDoNothing().given(caregiverService).updateCaregiverProfile(any(String.class), any(CaregiverProfileUpdateRequest.class));
+            willDoNothing().given(caregiverService).updateCaregiverProfile(any(String.class), any(CaregiverProfileUpdateRequest.class), any());
 
             // when & then
             mockMvc.perform(patch("/api/v1/caregiver")
@@ -127,10 +127,10 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
 
         @Test
         @WithCustomMockUserCaregiver
-        void 프로필_미등록시__예외가_발생한다() throws Exception {
+        void 프로필_미등록시_예외가_발생한다() throws Exception {
             // given
             CaregiverProfileUpdateRequest request = updateCaregiverProfileRequest();
-            willThrow(new EntityNotFoundException(ErrorCode.CAREGIVER_NOT_EXIST)).given(caregiverService).updateCaregiverProfile(any(String.class), any(CaregiverProfileUpdateRequest.class));
+            willThrow(new EntityNotFoundException(ErrorCode.CAREGIVER_NOT_EXIST)).given(caregiverService).updateCaregiverProfile(any(String.class), any(CaregiverProfileUpdateRequest.class), any());
 
             // when & then
             mockMvc.perform(patch("/api/v1/caregiver")

--- a/src/test/java/com/patientpal/backend/caregiver/service/CaregiverServiceTest.java
+++ b/src/test/java/com/patientpal/backend/caregiver/service/CaregiverServiceTest.java
@@ -59,7 +59,7 @@ class CaregiverServiceTest {
             CaregiverProfileCreateRequest request = createCaregiverProfileRequest();
 
             // when
-            CaregiverProfileResponse response = caregiverService.saveCaregiverProfile(member.getUsername(), request);
+            CaregiverProfileResponse response = caregiverService.saveCaregiverProfile(member.getUsername(), request, any(String.class));
 
             // then
             assertNotNull(response);
@@ -75,7 +75,7 @@ class CaregiverServiceTest {
             when(memberRepository.findByUsername(member.getUsername())).thenReturn(Optional.of(member));
 
             // when & then
-            assertThatThrownBy(() -> caregiverService.saveCaregiverProfile(member.getUsername(), request))
+            assertThatThrownBy(() -> caregiverService.saveCaregiverProfile(member.getUsername(), request, any(String.class)))
                     .isInstanceOf(AuthorizationException.class);
         }
 
@@ -138,7 +138,7 @@ class CaregiverServiceTest {
             CaregiverProfileUpdateRequest request = updateCaregiverProfileRequest();
 
             // when
-            caregiverService.updateCaregiverProfile(caregiver.getMember().getUsername(), request);
+            caregiverService.updateCaregiverProfile(caregiver.getMember().getUsername(), request, any(String.class));
 
             // then
             assertThat(caregiver.getCaregiverSignificant()).isEqualTo(UPDATE_CAREGIVER_SIGNIFICANT);
@@ -153,7 +153,7 @@ class CaregiverServiceTest {
 
             // when, then
             assertThatThrownBy(
-                    () -> caregiverService.updateCaregiverProfile(caregiver.getMember().getUsername(), request))
+                    () -> caregiverService.updateCaregiverProfile(caregiver.getMember().getUsername(), request, any(String.class)))
                     .isInstanceOf(EntityNotFoundException.class);
         }
 

--- a/src/test/java/com/patientpal/backend/fixtures/image/ImageFixture.java
+++ b/src/test/java/com/patientpal/backend/fixtures/image/ImageFixture.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.fixtures.image;
+
+public class ImageFixture {
+
+    public static final String BUCKET = "test-bucket";
+    public static final String LOCATION = "us-east-1";
+    public static final String FILE_NAME = "test-file.txt";
+    public static final String PREFIX = "test-prefix";
+    public static final String USE_ONLY_ONE_FILE_NAME = "unique-test-file.txt";
+    public static final String PRESIGNED_URL = "https://" + BUCKET + ".s3." + LOCATION + ".amazonaws.com/" + PREFIX + "/" + USE_ONLY_ONE_FILE_NAME;
+}

--- a/src/test/java/com/patientpal/backend/image/service/PresignedUrlServiceTest.java
+++ b/src/test/java/com/patientpal/backend/image/service/PresignedUrlServiceTest.java
@@ -1,0 +1,68 @@
+package com.patientpal.backend.image.service;
+
+import static com.patientpal.backend.fixtures.image.ImageFixture.BUCKET;
+import static com.patientpal.backend.fixtures.image.ImageFixture.FILE_NAME;
+import static com.patientpal.backend.fixtures.image.ImageFixture.LOCATION;
+import static com.patientpal.backend.fixtures.image.ImageFixture.PREFIX;
+import static com.patientpal.backend.fixtures.image.ImageFixture.PRESIGNED_URL;
+import static com.patientpal.backend.fixtures.image.ImageFixture.USE_ONLY_ONE_FILE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.patientpal.backend.test.annotation.AutoKoreanDisplayName;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoKoreanDisplayName
+class PresignedUrlServiceTest {
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @InjectMocks
+    private PresignedUrlService presignedUrlService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(presignedUrlService, "bucket", BUCKET);
+        ReflectionTestUtils.setField(presignedUrlService, "location", LOCATION);
+    }
+
+    @Test
+    void PUT_MAPPING_진행할_AWS_S3_URL_전체_경로_반환에_성공한다() throws Exception {
+        // given
+        URL url = new URL(PRESIGNED_URL);
+        System.out.println(url);
+        given(amazonS3.generatePresignedUrl(any(GeneratePresignedUrlRequest.class))).willReturn(url);
+
+        // when
+        String presignedUrl = presignedUrlService.getPresignedUrl(PREFIX, FILE_NAME);
+
+        // then
+        assertThat(presignedUrl).isEqualTo(url.toString());
+    }
+
+    @Test
+    void 프로필_이미지를_조회할_URL을_가져오기_성공한다() {
+        // given
+        ReflectionTestUtils.setField(presignedUrlService, "useOnlyOneFileName", USE_ONLY_ONE_FILE_NAME);
+
+        // when
+        String signedUrl = presignedUrlService.findByName(PREFIX);
+        System.out.println(signedUrl);
+
+        // then
+        assertThat(signedUrl).isEqualTo(PRESIGNED_URL);
+    }
+}

--- a/src/test/java/com/patientpal/backend/patient/controller/PatientControllerV1Test.java
+++ b/src/test/java/com/patientpal/backend/patient/controller/PatientControllerV1Test.java
@@ -45,7 +45,7 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
             // given
             PatientProfileCreateRequest request = createPatientProfileRequest();
             PatientProfileResponse response = createPatientProfileResponse();
-            given(patientService.savePatientProfile(any(String.class), any(PatientProfileCreateRequest.class))).willReturn(response);
+            given(patientService.savePatientProfile(any(String.class), any(PatientProfileCreateRequest.class), any())).willReturn(response);
 
             // when & then
             mockMvc.perform(post("/api/v1/patient")
@@ -115,7 +115,7 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
         void 성공한다() throws Exception {
             // given
             PatientProfileUpdateRequest request = updatePatientProfileRequest();
-            willDoNothing().given(patientService).updatePatientProfile(any(String.class), any(PatientProfileUpdateRequest.class));
+            willDoNothing().given(patientService).updatePatientProfile(any(String.class), any(PatientProfileUpdateRequest.class), any());
 
             // when & then
             mockMvc.perform(patch("/api/v1/patient")
@@ -130,7 +130,7 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
         void 프로필이_없으면_예외가_발생한다() throws Exception {
             // given
             PatientProfileUpdateRequest request = updatePatientProfileRequest();
-            willThrow(new EntityNotFoundException(ErrorCode.PATIENT_NOT_EXIST)).given(patientService).updatePatientProfile(any(String.class), any(PatientProfileUpdateRequest.class));
+            willThrow(new EntityNotFoundException(ErrorCode.PATIENT_NOT_EXIST)).given(patientService).updatePatientProfile(any(String.class), any(PatientProfileUpdateRequest.class), any());
 
             // when & then
             mockMvc.perform(patch("/api/v1/patient")

--- a/src/test/java/com/patientpal/backend/patient/service/PatientServiceTest.java
+++ b/src/test/java/com/patientpal/backend/patient/service/PatientServiceTest.java
@@ -59,7 +59,7 @@ class PatientServiceTest {
             PatientProfileCreateRequest request = createPatientProfileRequest();
 
             // when
-            PatientProfileResponse response = patientService.savePatientProfile(member.getUsername(), request);
+            PatientProfileResponse response = patientService.savePatientProfile(member.getUsername(), request, any(String.class));
 
             // then
             assertNotNull(response);
@@ -75,7 +75,7 @@ class PatientServiceTest {
             when(memberRepository.findByUsername(member.getUsername())).thenReturn(Optional.of(member));
 
             // when & then
-            assertThatThrownBy(() -> patientService.savePatientProfile(member.getUsername(), request))
+            assertThatThrownBy(() -> patientService.savePatientProfile(member.getUsername(), request, any(String.class)))
                     .isInstanceOf(AuthorizationException.class);
         }
 
@@ -137,7 +137,7 @@ class PatientServiceTest {
             PatientProfileUpdateRequest request = updatePatientProfileRequest();
 
             // when
-            patientService.updatePatientProfile(patient.getMember().getUsername(), request);
+            patientService.updatePatientProfile(patient.getMember().getUsername(), request, any(String.class));
 
             // then
             assertThat(patient.getPatientSignificant()).isEqualTo(UPDATE_PATIENT_SIGNIFICANT);
@@ -151,7 +151,7 @@ class PatientServiceTest {
             PatientProfileUpdateRequest request = updatePatientProfileRequest();
 
             // when & then
-            assertThatThrownBy(() -> patientService.updatePatientProfile(patient.getMember().getUsername(), request))
+            assertThatThrownBy(() -> patientService.updatePatientProfile(patient.getMember().getUsername(), request, any(String.class)))
                     .isInstanceOf(EntityNotFoundException.class);
         }
 


### PR DESCRIPTION
## ✨ 작업 내용
- 서버의 부하를 줄이기 위해 multipart가 아닌, presigned url을 이용해 이미지 업로드를 진행하였습니다.
- 클라이언트 측에서 @PostMapping("/presigned")를 하면 이후 리턴된 url로 PutMapping을 이어서 진행하여야 합니다. (프론트엔드랑 논의)
- 프로필 등록 시, 수정 시 이미지 등록, 변경이 가능하게 구현하였습니다.
- 프로필에서 사진만 삭제할 수 있도록 구현하였습니다.
- 인가받은 사용자만 이미지 등록을 할 수 있고, url 접근 만료 기간을 짧게 잡음으로써 보안을 강화하였습니다.
- 추후 대용량 이미지 관리를 위해 이미지 리사이징, 색변환 등을 진행할 예정입니다.

- 동작 과정
  1. 프로필 등록 시 이미지를 선택한다.
  2. 이후 프로필 등록 최종 완료 버튼 누를 시 @PostMapping("api/v1/caregiver/presigned") 가 호출된다.
  3. 프론트엔드에서 이미지 이름을 매개변수로 넘기면서 aws s3에 저장될 전체 경로가 반환된다.
  4. 반환된 경로로 사진을 첨부하여 @PutMapping을 곧바로 이어서 진행하면 그 경로에 이미지가 저장된다.
  5. 프로필에 경로가 저장된다. 이후 조회 가능.

=> 즉, 프로필 등록 완료 버튼을 누를 때, 
   1. @PostMapping("api/v1/caregiver/presigned")을 호출하여 사용자가 올린 이미지 이름으로 s3에 저장될 전체 url 가져옴(쿼리 파라미터 포함)
   2. @PutMapping  - s3에 실제 이미지 첨부
   3. @PostMapping("api/v1/caregiver") 을 호출하여 간병인 프로필에 image 조회용 s3 저장소 url 저장. (requestDto에 이미지 이름 같이 넘겨야 함)

## 💬 리뷰어에게 남길 멘트
- 테스트 수정 중 실패하는 부분이 있어 원인 파악 후 수정하여 커밋 예정입니다.
- 보안 유출 문제, 코드 심각한 에러 발생 요소 등 검토 부탁드립니다

## 🔗 관련 이슈
- Closes #87 

## 📚 레퍼런스
- https://aws.amazon.com/ko/blogs/korea/uploading-to-amazon-s3-directly-from-a-web-or-mobile-application/
- https://leeeeeyeon-dev.tistory.com/88
- https://velog.io/@wonizizi99/Web-%ED%94%84%EB%A1%A0%ED%8A%B8%EB%B2%A1%EC%95%A4%EB%93%9C7spring-boot-S3-pre-signed-URL-%EC%A0%81%EC%9A%A9